### PR TITLE
Change None to NONE in WinSeparator highlight

### DIFF
--- a/colors/carbon.vim
+++ b/colors/carbon.vim
@@ -189,5 +189,5 @@ highlight! link Whitespace Comment
 highlight! link SpecialKey Directory
 
 if &laststatus ==# '3'
-  call s:highlight('WinSeparator', 'None', s:carbon_Color16, '')
+  call s:highlight('WinSeparator', 'NONE', s:carbon_Color16, '')
 endif


### PR DESCRIPTION
When using laststatus=3 in Vim having the highlight be `None` instead of `NONE` produces an error.